### PR TITLE
Add support of authored state API

### DIFF
--- a/src/assets/iframe.html
+++ b/src/assets/iframe.html
@@ -16,6 +16,7 @@
         <h4> Mock Interactive: </h4>
         <button class='button' id='getAuthInfo'>getAuthInfo</button>
         <button class='button' id='globalSaveState'>globalSaveState</button>
+        <button class='button' id='saveAuthoredState'>saveAuthoredState</button>
       </div>
       
       <div class="flex row">
@@ -28,6 +29,11 @@
           <label>State</label>
           <br/>
           <textarea name='interactiveState' id="interactiveState">{"fake": "data", "for": "you"}</textarea>
+        </div>
+        <div>
+          <label>Authored State</label>
+          <br/>
+          <textarea name='interactiveState' id="authoredState">{"fake": "data", "for": "you"}</textarea>
         </div>
       </div>
 

--- a/src/code/iframe.coffee
+++ b/src/code/iframe.coffee
@@ -50,6 +50,9 @@ module.exports = class MockInteractive
 
     @iframePhone.addListener 'initInteractive', (data) ->
       l.info "Phone call: initInteractive: #{JSON.stringify data}"
+      $('#interactiveState').val JSON.stringify(data.interactiveState) if data.interactiveState
+      $('#authoredState').val JSON.stringify(data.authoredState) if data.authoredState
+      $('#interactiveStateGlobal').val JSON.stringify(data.globalInteractiveState) if data.globalInteractiveState
 
     # Logging
     logTheLogMessages = (message, callback) ->
@@ -84,5 +87,9 @@ module.exports = class MockInteractive
     $('#globalSaveState').click () =>
       l.info('posting interactiveStateGlobal')
       @iframePhone.post("interactiveStateGlobal", JSON.parse($('#interactiveStateGlobal').val()))
+
+    $('#saveAuthoredState').click () =>
+      l.info('posting authoredState')
+      @iframePhone.post("authoredState", JSON.parse($('#authoredState').val()))
 
 window.MockInteractive = MockInteractive


### PR DESCRIPTION
Authored state API:

1. Interactive can send `authoredState` message to parent using iframe phone.

2. `initInteractive` call from parent might include two new properties:
     - `mode` - "runtime" or "authoring"
     - `authoredState` - anything that was previously provided by interactive in `authoredStat` call

@scytacki, could you look at it? It would be nice to agree on this API, so I can continue work on LARA and interactives that we want to customize. I think it's pretty straightforward, but not sure if "authored state" is the best name. I could imagine "config" but then it can be confusing, e.g. the difference between "state" and "config" won't be obvious.

Also, I'm assuming that we slowly want to move as much as possible into `initInteractive` call (because of comments in PT story and code), so I'm not going to implement separate `loadAuthoredState` call in LARA. Although, it could simplify implementation a bit (or make it safer). Is that right?

I know that other parts of this repo could be updated too (parent page, docs), but I wanted to update iframe first (so I can use it for tests in LARA) and agree on API. Once things are stable, I'll document them better.