### PR TITLE
Authored state, supported features + new format of docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .project
 .settings
 .tmproj
+.idea
 nbproject
 Thumbs.db
 

--- a/docs/implementing-interactive.md
+++ b/docs/implementing-interactive.md
@@ -1,0 +1,86 @@
+# Implementing Interactive
+
+LARA embeds interactives using iframe and provides LARA Interactive API. This API can be used e.g. to customize interactive,
+save state authored by teachers or save student progress. The whole communication between LARA and Interactive
+happens through [iFramePhone](https://github.com/concord-consortium/iframe-phone) which is a simple wrapper around 
+`postMessage` API. Interactive which wants to use LARA Interactive API needs to use this library. Check its 
+readme to see how to include it in your project (npm, RequireJS or via script tag). Once `iframePhone` library is 
+available, Interactive needs to setup communication:
+
+### iframe-phone setup
+```javascript
+var phone = iframePhone.getIFrameEndpoint();
+phone.addListener('initInteractive', function (data) {
+  // handle initInteractive call
+});
+phone.addListener('otherMessageType', function (data) {
+  // handle otherMessageType call
+});
+// more handlers here 
+// (...)
+// IMPORTANT: Initialize connection after all message listeners are added!
+phone.initialize();
+```
+
+### Handling the `initInteractive` message
+
+This is one of the most important messages sent by LARA. It provides most of the information stored by LARA.
+It tells the interactive what is the current API version, mode (`runtime` or `authoring`), `authoredState` (state defined by teacher), 
+`interactiveState` (state based on student work) and so on. Interactive should add `initInteractive` handler that
+reads values stored in `data` Object / hash:
+
+```javascript
+phone.addListener('initInteractive', function (data) {
+  // process data object, e.g.:
+  // initializeMode(data.mode);
+  // loadAuthoredState(data.authoredState);
+  // loadStudentWork(data.interactiveState);
+});  
+```
+
+`data` consists of:
+
+ - error - `null` if everything is okay, error message otherwise (e.g. data fetching might fail).
+ - mode - `"authoring"` or `"runtime"`. Interactive can be displayed in one of those two modes, but it's up to interactive whether
+ it supports authoring mode. Runtime is basic mode which is presented to students. Authoring mode can be used
+ by authors to customize interactive.
+ - **[optional]** authoredState - JSON that has been saved by interactive earlier in authoring mode using `authoredState` message (described
+ below in other section). If it's not defined, it would be falsy value (null or empty string).
+ - **[optional]** interactiveState - JSON that has been saved by interactive earlier in runtime mode using `interactiveState` message (described
+ below in other section). Provided only in runtime mode. If it's not defined, it would be falsy value (null or empty string).
+ - **[optional]** globalInteractiveState - JSON that has been saved by interactive earlier in runtime mode using `globalInteractiveState` message (described
+ below in other section). Provided only in runtime mode. If it's not defined, it would be falsy value (null or empty string).
+ - **[optional]** hasLinkedInteractive
+ - **[optional]** linkedState
+ - **[optional]** interactiveStateUrl
+ - **[optional]** collaboratorUrls
+ 
+
+### Interactive customization
+
+`initInteractive` provides `mode` property. Interactive can display authoring interface when mode value is equal
+to `"authoring"`. Every customization made by author should be sent back to LARA using `authoredState` message:
+
+```javascript
+phone.post('authoredState', authoredState);  
+```
+
+There are no requirements regarding `authoredState` expect from the fact that it should be a JSON.
+Next time the interactive is loaded either in authoring or runtime mode, `initInteractive` will provide this state to the interactive 
+in `authoredState` property.
+Note that it's recommended that `authoredState` should be sent to LARA immediately after every change. LARA provides
+its own "Save" button that would actually save this state to the DB and "Reset" which would set it back to null.
+
+### Saving student progress
+
+`initInteractive` provides `mode` property. `"runtime"` mode means that Interactive is viewed by student. Interactive
+ can save student progress using `interactiveState` message:
+ 
+ 
+```javascript
+phone.post('interactiveState', interactiveState);  
+```
+ 
+ There are no requirements regarding `interactiveState` expect from the fact that it should be a JSON.
+ Next time the interactive is loaded either in runtime mode, `initInteractive` will provide this state to the interactive
+ in `interactiveState` property.

--- a/docs/implementing-interactive.md
+++ b/docs/implementing-interactive.md
@@ -58,7 +58,19 @@ phone.addListener('initInteractive', function (data) {
 
 ### Interactive customization
 
-`initInteractive` provides `mode` property. Interactive can display authoring interface when mode value is equal
+If interactive wants to support customization, it should inform LARA about it using `supportedFeatures` message:
+ 
+```javascript
+phone.post('supportedFeatures', {
+  apiVersion: 1, 
+  features: {
+    authoredState: true 
+    // + other supported features
+  }
+});  
+``` 
+
+`initInteractive` message provides `mode` property. Interactive can display authoring interface when mode value is equal
 to `"authoring"`. Every customization made by author should be sent back to LARA using `authoredState` message:
 
 ```javascript
@@ -72,6 +84,18 @@ Note that it's recommended that `authoredState` should be sent to LARA immediate
 its own "Save" button that would actually save this state to the DB and "Reset" which would set it back to null.
 
 ### Saving student progress
+
+If interactive wants to support student progress saving, it should inform LARA about it using `supportedFeatures` message:
+ 
+```javascript
+phone.post('supportedFeatures', {
+  apiVersion: 1, 
+  features: {
+    interactiveState: true 
+    // + other supported features
+  }
+});  
+``` 
 
 `initInteractive` provides `mode` property. `"runtime"` mode means that Interactive is viewed by student. Interactive
  can save student progress using `interactiveState` message:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ repo_url: https://github.com/concord-consortium/lara-interactive-api
 site_url: http://concord-consortium.github.io/lara-interactive-api/
 pages:
 - LARA Interactive API: 'index.md'
+- Implementing Interactive: 'implementing-interactive.md'
 - Shutterbug API: 'shutterbug.md'
 - Using iFramePhone: 'using-iframe-phone.md'
 - Safari / IE, cookies and iframe redirects: 'safari-cookies-redirects.md'

--- a/src/assets/iframe.html
+++ b/src/assets/iframe.html
@@ -21,11 +21,6 @@
       
       <div class="flex row">
         <div>
-          <label>Global State</label>
-          <br/>
-          <textarea name='interactiveState' id="interactiveStateGlobal">{"fake": "data", "for": "you"}</textarea>
-        </div>
-        <div>
           <label>State</label>
           <br/>
           <textarea name='interactiveState' id="interactiveState">{"fake": "data", "for": "you"}</textarea>
@@ -34,6 +29,11 @@
           <label>Authored State</label>
           <br/>
           <textarea name='interactiveState' id="authoredState">{"fake": "data", "for": "you"}</textarea>
+        </div>
+        <div>
+          <label>Global State</label>
+          <br/>
+          <textarea name='interactiveState' id="interactiveStateGlobal">{"fake": "data", "for": "you"}</textarea>
         </div>
       </div>
 

--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -115,7 +115,7 @@
                 value= "http://lab.concord.org/embeddable.html#interactives/interactions/charge-table-U1-Inv1.json" />
       </div>
       <iframe id="interactive-iframe"
-        width="500"
+        width="650"
         height="400"
         allowfullscreen="true"
         scrolling="no"

--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -132,10 +132,12 @@ class App
     messageHandlers =
       "setLearnerUrl": false
       "interactiveState": false
+      "authoredState": false
       "getAuthInfo":
         message: "authInfo"
         data: "knowuh@gmail.com"
       "extendedSupport": false
+      "supportedFeatures": false
       "interactiveStateGlobal":
         handler: (data) =>
           @globalState = _.extend(@globalState,data)

--- a/src/code/iframe.coffee
+++ b/src/code/iframe.coffee
@@ -69,6 +69,15 @@ module.exports = class MockInteractive
     @iframePhone.initialize()
     l.info("Phone ready")
 
+    @iframePhone.post("supportedFeatures", {
+      apiVersion: 1,
+      features: {
+        authoredState: true,
+        interactiveState: true
+      }
+    })
+    l.info("Posted supported features")
+
     # TODO: (rpc)
     # @iframePhoneRpc = new iframePhone.IframePhoneRpcEndpoint
     #   phone: @iframePhone


### PR DESCRIPTION
This PR provides a few things:
- documents `authoredState` message
- documents `supportedFeatures` message
- adds examples to the code (parent page and iframe)

It also provides this documentation in a new format that we discussed before - focused on interactive developers, not LARA developers. I tried to move there most of the features that I'm familiar with. However I skipped a few messages on purpose:

- `getLearnerUrl` is not necessary, new Interactives can just send `setLearnerUrl` without waiting for `getLearnerUrl` to make things simpler
- `loadInteractive` and `loadInteractiveGlobal` also are not necessary, new interactives should just use `initInteractive` instead

Also, I skipped a few fields and features I'm not sure about (linkedInteractives, collaboratorsUrl, extendedSupport). Maybe that can be updated by developers that were working on it during our "1h Friday refactoring" soon.

@scytacki, I know you started something similar: https://github.com/concord-consortium/lara-interactive-api/pull/3

Personally, I wanted to group messages by features rather than list them one by on. So, it's clear which messages are actually useful for given interactive. But we can try to merge both approaches somehow or change this one, feel free to comment on this. Also, you probably have used better wording. :)